### PR TITLE
Add hint to reduce number of photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ this.sendNotification("NEXTCLOUD_REFRESH_LIST");
    - Verify Nextcloud URL and credentials
    - Check that the path contains image files
    - Review browser console for errors
+   - Check that the choosen folder does not contain to much photos. It is possible to create an album in the nextcloud Photos App and use this one in the configuration file to reduce the number of photos. This way there is no need create copys of pictures in another folder. The path variable in the configuration would be:
+     path: "https://your-nextcloud.com/remote.php/dav/photos/username/albums/albumname/",
 
 2. **Authentication failed**
    - Use app password instead of main password

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ this.sendNotification("NEXTCLOUD_REFRESH_LIST");
    - Verify Nextcloud URL and credentials
    - Check that the path contains image files
    - Review browser console for errors
-   - Check that the choosen folder does not contain to much photos. It is possible to create an album in the nextcloud Photos App and use this one in the configuration file to reduce the number of photos. This way there is no need create copys of pictures in another folder. The path variable in the configuration would be:
+   - Check that the chosen folder does not contain too many photos. It is possible to create an album in the Nextcloud Photos app and use it in the configuration file to reduce the number of photos. This way, there is no need to create copies of pictures in another folder. The path variable in the configuration would be:
+     ```javascript
      path: "https://your-nextcloud.com/remote.php/dav/photos/username/albums/albumname/",
+     ```
 
 2. **Authentication failed**
    - Use app password instead of main password


### PR DESCRIPTION
I had the same problem like in #1. Maybe it is common knowledge that albums in the photos app can be used in webdav too, but for me it was not and it is a very easy and clean way to choose some photos without making a copy like it is written #1. So i added this hint to the readme.