### PR TITLE
Made exif display use dateFormat

### DIFF
--- a/MMM-Nextcloud.js
+++ b/MMM-Nextcloud.js
@@ -36,7 +36,11 @@ Module.register("MMM-Nextcloud", {
         showExifData: true,
         enableGeocoding: true, // Enable reverse geocoding for GPS coordinates to location names
         showOsmAttribution: true, // Show OpenStreetMap attribution when location data is displayed
-        dateFormat: "DD MMMM YYYY", // Custom date format for EXIF data display
+        dateFormat: {  // Custom date format for EXIF data display
+            year: 'numeric', 
+            month: 'long', 
+            day: '2-digit' 
+        }
     },
 
     start: function() {
@@ -344,12 +348,7 @@ Module.register("MMM-Nextcloud", {
             }
             
             // Simple date formatting - could be enhanced with moment.js alternative
-            const options = { 
-                year: 'numeric', 
-                month: 'long', 
-                day: '2-digit' 
-            };
-            return date.toLocaleDateString('en-US', options);
+            return date.toLocaleDateString(config.locale, this.config.dateFormat);
         } catch (error) {
             Log.warn(`[${this.name}] Failed to format date: ${dateString}`);
             return dateString;

--- a/MMM-Nextcloud.js
+++ b/MMM-Nextcloud.js
@@ -348,7 +348,17 @@ Module.register("MMM-Nextcloud", {
             }
             
             // Simple date formatting - could be enhanced with moment.js alternative
-            return date.toLocaleDateString(config.locale, this.config.dateFormat);
+            let dateFormat = this.config.dateFormat;
+            if (typeof(dateFormat) !== 'object') {
+                // Backwards compatible: If the dateFormat is still a string (like 'DD MM YYYY'), replace it with the default.
+                // This is exactly the previous behavior.
+                dateFormat = {
+                    year: 'numeric', 
+                    month: 'long', 
+                    day: '2-digit' 
+                }
+            }
+            return date.toLocaleDateString(config.locale, dateFormat);
         } catch (error) {
             Log.warn(`[${this.name}] Failed to format date: ${dateString}`);
             return dateString;

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ Add the module to your `config/config.js` file:
         showExifData: true,
         enableGeocoding: true, // Enable reverse geocoding for GPS coordinates
         showOsmAttribution: false, // Show OpenStreetMap attribution when location data is displayed
-        dateFormat: "DD MMMM YYYY", // Custom date format
+        dateFormat: { 
+            year: 'numeric', 
+            month: 'long', 
+            day: '2-digit' 
+        }, // Custom date format
         showStatusIcon: true,
         statusIconPosition: "top_right", // top_right, top_left, bottom_right, bottom_left
         statusIconMode: "show", // show, fade
@@ -120,7 +124,7 @@ For security, use Nextcloud app passwords instead of your main password:
 | `showExifData` | boolean | `true` | Display EXIF data (date/location) |
 | `enableGeocoding` | boolean | `true` | Enable reverse geocoding to convert GPS coordinates to location names |
 | `showOsmAttribution` | boolean | `false` | Show OpenStreetMap attribution when location data is displayed |
-| `dateFormat` | string | `"DD MMMM YYYY"` | Date format for EXIF display |
+| `dateFormat` | object | `{year: 'numeric', month: 'long', day: '2-digit'}` | Date format for EXIF display (For specification see Date.prototype.toLocaleDateString()) |
 | `showStatusIcon` | boolean | `true` | Show status icon |
 | `statusIconPosition` | string | `"top_right"` | Icon position: top_right, top_left, bottom_right, bottom_left |
 | `statusIconMode` | string | `"show"` | Icon behavior: show, fade |


### PR DESCRIPTION
I noticed that `dateFormat`, listed in the readme file, is never used. (Or did I misunderstand something there?)

I used `toLocaleDateString()`, like you already did, so `dateFormat` defines the object to use for this function.